### PR TITLE
Fix Docker and docker-compose

### DIFF
--- a/DivisionManagementSystem/settings.py
+++ b/DivisionManagementSystem/settings.py
@@ -28,12 +28,11 @@ SECRET_KEY = os.environ['SECRET_KEY']
 DEBUG = bool(os.environ['DEBUG'])
 
 if DEBUG:
-    ALLOWED_HOSTS = ['127.0.0.1']
+    ALLOWED_HOSTS = ['127.0.0.1', '0.0.0.0', 'localhost']
 else:
     ALLOWED_HOSTS = ['mvbachman.com', 'www.mvbachman.com']
 
 # Application definition
-
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -121,21 +120,15 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
-
 LANGUAGE_CODE = 'en-us'
-
 TIME_ZONE = 'UTC'
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
-
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
@@ -143,23 +136,17 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
 # Custom User & Log In
-
 AUTH_USER_MODEL = 'employees.Employee'
-
 LOGIN_REDIRECT_URL = 'main-home'
-
 LOGIN_URL = 'login'
 
 # Crispy Forms
-
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # Phone Number Handling
-
 PHONENUMBER_DEFAULT_REGION = "US"
 
 # Django Messages
-
 MESSAGE_TAGS = {
     messages.ERROR: 'danger',
 }

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,8 @@ titlecase = "~=1.1.1"
 Django = "~=3.1.1"
 Pillow = "~=8.0.1"
 PyPDF2 = "~=1.26.0"
-psycopg2 = "~=2.8.6"
+psycopg2-binary = "~=2.8.6"
+gunicorn = "~=20.0.0"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "814cfd3d64038266670efd62b3088cf263b681fa988ea8bd4406e31d4ae76288"
+            "sha256": "5adb60257640115f3aa461633773a563f3554f28fc32d6c37172e0ecb3411602"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -144,6 +144,14 @@
             ],
             "version": "==1.0.1"
         },
+        "gunicorn": {
+            "hashes": [
+                "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626",
+                "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"
+            ],
+            "index": "pypi",
+            "version": "==20.0.4"
+        },
         "jdcal": {
             "hashes": [
                 "sha256:1abf1305fce18b4e8aa248cf8fe0c56ce2032392bc64bbd61b5dff2a19ec8bba",
@@ -231,23 +239,43 @@
             "markers": "python_full_version >= '3.6.1'",
             "version": "==3.0.8"
         },
-        "psycopg2": {
+        "psycopg2-binary": {
             "hashes": [
-                "sha256:00195b5f6832dbf2876b8bf77f12bdce648224c89c880719c745b90515233301",
-                "sha256:068115e13c70dc5982dfc00c5d70437fe37c014c808acce119b5448361c03725",
-                "sha256:26e7fd115a6db75267b325de0fba089b911a4a12ebd3d0b5e7acb7028bc46821",
-                "sha256:2c93d4d16933fea5bbacbe1aaf8fa8c1348740b2e50b3735d1b0bf8154cbf0f3",
-                "sha256:56007a226b8e95aa980ada7abdea6b40b75ce62a433bd27cec7a8178d57f4051",
-                "sha256:56fee7f818d032f802b8eed81ef0c1232b8b42390df189cab9cfa87573fe52c5",
-                "sha256:6a3d9efb6f36f1fe6aa8dbb5af55e067db802502c55a9defa47c5a1dad41df84",
-                "sha256:a49833abfdede8985ba3f3ec641f771cca215479f41523e99dace96d5b8cce2a",
-                "sha256:ad2fe8a37be669082e61fb001c185ffb58867fdbb3e7a6b0b0d2ffe232353a3e",
-                "sha256:b8cae8b2f022efa1f011cc753adb9cbadfa5a184431d09b273fb49b4167561ad",
-                "sha256:d160744652e81c80627a909a0e808f3c6653a40af435744de037e3172cf277f5",
-                "sha256:d5062ae50b222da28253059880a871dc87e099c25cb68acf613d9d227413d6f7",
-                "sha256:f22ea9b67aea4f4a1718300908a2fb62b3e4276cf00bd829a97ab5894af42ea3",
-                "sha256:f974c96fca34ae9e4f49839ba6b78addf0346777b46c4da27a7bf54f48d3057d",
-                "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"
+                "sha256:0deac2af1a587ae12836aa07970f5cb91964f05a7c6cdb69d8425ff4c15d4e2c",
+                "sha256:0e4dc3d5996760104746e6cfcdb519d9d2cd27c738296525d5867ea695774e67",
+                "sha256:11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0",
+                "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6",
+                "sha256:1fabed9ea2acc4efe4671b92c669a213db744d2af8a9fc5d69a8e9bc14b7a9db",
+                "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94",
+                "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52",
+                "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056",
+                "sha256:6a32f3a4cb2f6e1a0b15215f448e8ce2da192fd4ff35084d80d5e39da683e79b",
+                "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd",
+                "sha256:7d92a09b788cbb1aec325af5fcba9fed7203897bbd9269d5691bb1e3bce29550",
+                "sha256:833709a5c66ca52f1d21d41865a637223b368c0ee76ea54ca5bad6f2526c7679",
+                "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83",
+                "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77",
+                "sha256:950bc22bb56ee6ff142a2cb9ee980b571dd0912b0334aa3fe0fe3788d860bea2",
+                "sha256:a0c50db33c32594305b0ef9abc0cb7db13de7621d2cadf8392a1d9b3c437ef77",
+                "sha256:a0eb43a07386c3f1f1ebb4dc7aafb13f67188eab896e7397aa1ee95a9c884eb2",
+                "sha256:aaa4213c862f0ef00022751161df35804127b78adf4a2755b9f991a507e425fd",
+                "sha256:ac0c682111fbf404525dfc0f18a8b5f11be52657d4f96e9fcb75daf4f3984859",
+                "sha256:ad20d2eb875aaa1ea6d0f2916949f5c08a19c74d05b16ce6ebf6d24f2c9f75d1",
+                "sha256:b4afc542c0ac0db720cf516dd20c0846f71c248d2b3d21013aa0d4ef9c71ca25",
+                "sha256:b8a3715b3c4e604bcc94c90a825cd7f5635417453b253499664f784fc4da0152",
+                "sha256:ba28584e6bca48c59eecbf7efb1576ca214b47f05194646b081717fa628dfddf",
+                "sha256:ba381aec3a5dc29634f20692349d73f2d21f17653bda1decf0b52b11d694541f",
+                "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729",
+                "sha256:c2507d796fca339c8fb03216364cca68d87e037c1f774977c8fc377627d01c71",
+                "sha256:cec7e622ebc545dbb4564e483dd20e4e404da17ae07e06f3e780b2dacd5cee66",
+                "sha256:d14b140a4439d816e3b1229a4a525df917d6ea22a0771a2a78332273fd9528a4",
+                "sha256:d1b4ab59e02d9008efe10ceabd0b31e79519da6fb67f7d8e8977118832d0f449",
+                "sha256:d5227b229005a696cc67676e24c214740efd90b148de5733419ac9aaba3773da",
+                "sha256:e1f57aa70d3f7cc6947fd88636a481638263ba04a742b4a37dd25c373e41491a",
+                "sha256:e74a55f6bad0e7d3968399deb50f61f4db1926acf4a6d83beaaa7df986f48b1c",
+                "sha256:e82aba2188b9ba309fd8e271702bd0d0fc9148ae3150532bbb474f4590039ffb",
+                "sha256:ee69dad2c7155756ad114c02db06002f4cded41132cc51378e57aad79cc8e4f4",
+                "sha256:f5ab93a2cb2d8338b1674be43b442a7f544a0971da062a5da774ed40587f18f5"
             ],
             "index": "pypi",
             "version": "==2.8.6"

--- a/dms.Dockerfile
+++ b/dms.Dockerfile
@@ -11,9 +11,6 @@ ENV PIP_NO_CACHE_DIR=false \
 # Install project dependencies
 RUN pip install -U pipenv
 
-# install psycopg2 dependencies
-RUN apt update && apt -y install postgresql gcc libpq-dev postgresql-client postgresql-client-common
-
 # Copy the project files into working directory
 COPY . .
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,16 @@ services:
       - .env
     depends_on:
       - db
+
+    # Bind volumes to enable hot-reloads.
+    # e.g. when a file is changed in this folder, the change is
+    # also applied to the same file inside the docker container.
+    volumes:
+      - ./DivisionManagementSystem/:/DivisionManagementSystem/
+      - ./employees/:/employees/
+      - ./main/:/main/
+      - ./operations/:/operations/
+      - ./templates/:/templates/
   db:
     image: postgres:12.0-alpine
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,18 +30,18 @@ services:
   db:
     image: postgres:12.0-alpine
     restart: always
-    container_name: postgres
+    container_name: postgres_dms
     environment:
       - POSTGRES_USER=dms
       - POSTGRES_PASSWORD=admin123
       - POSTGRES_DB=dms-db
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - ${POSTGRES_DATA}:/var/lib/postgresql/data/
+    ports:
+      - 5432:5432
   redis:
     image: redis
     restart: always
-    container_name: redis
+    container_name: redis_dms
     ports:
       - 6379:6379
-volumes:
-  postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   dms:
-    # image: /dms:latest
+    image: mvbachman/dms:latest
     build:
       context: .
       dockerfile: dms.Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,11 @@ services:
       dockerfile: dms.Dockerfile
     container_name: dms
     restart: always
+
+    # Usually a good idea to not use 8000, other services may want it.
     ports:
-      - 8000:8000
+      - 8001:8001
+
     env_file:
       - .env
     depends_on:

--- a/main/management/commands/start.py
+++ b/main/management/commands/start.py
@@ -32,4 +32,5 @@ class Command(BaseCommand):
 
         call_command("migrate")
         call_command("collectstatic", interactive=False, clear=True)
-        call_command("runserver")
+        os.system("gunicorn --preload -b 0.0.0.0:8001 DivisionManagementSystem.wsgi:application --threads 8 -w 4")
+        exit()


### PR DESCRIPTION
This pull request makes a few minor changes that allows the docker to run the way it should.

## Changes
- Switches `psycopg2` to `psycopg2-binary`
- Simplifies Dockerfile
- Sets up `gunicorn` as the default server
- Exposes the server on port 8001
- Use an environment variable to set the postgres data volume.
- Adds more debug-mode allowed hosts
- Hot reloads should now work even when running in docker


This pull request has been split into several small, atomic commits with commit messages that explain what they are doing - take a look through the commits so you can understand all the changes before merging them.