### PR TITLE
Fix form_preloader

### DIFF
--- a/main/static/JS/form_preloader.js
+++ b/main/static/JS/form_preloader.js
@@ -27,6 +27,7 @@ $(document).ready(function() {
                     var p = $("<p>", {id: "error_1_id_" + key, "class": "invalid-feedback"});
                     var strong = $("<strong>").text(value);
 
+                    parent.find('p').remove();
                     p.append(strong);
                     parent.append(p);
                     p.show()


### PR DESCRIPTION
In the past errors would just get appended. So if an error was submitted
the error would be appended to the field then if another error was
submitted and the previous one was fixed then it would still show the
old error.