### PR TITLE
Fix conditional for filling notification box

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -40,7 +40,7 @@
     </head>
     <body>
         <script src="{% static 'notifications/notify.js' %}" type="text/javascript"></script>
-        {% if user.authenticated %}
+        {% if user.is_authenticated %}
             <script>
                 function generate_notification_list(data) {
                     let time_str;


### PR DESCRIPTION
I accidentally misspelled the field to authenticated as opposed to
is_authenticated. Without this fix the notification box would never fill
up.