### PR TITLE
Add try accept when deleting hold

### DIFF
--- a/employees/forms.py
+++ b/employees/forms.py
@@ -551,8 +551,10 @@ class AssignSettlement(forms.Form):
             assigned_by=request.user.employee_id,
         )
 
-        if employee.hold:
+        try:
             employee.hold.delete()
+        except Hold.DoesNotExist:
+            pass
 
         settlement.save()
 


### PR DESCRIPTION
If a hold did not exists then there would be a server error. This
ensures to catch that error and do nothing if it pops up.

closes #155 