### PR TITLE
Fix 500 error when there is a new counseling

### DIFF
--- a/employees/forms.py
+++ b/employees/forms.py
@@ -181,7 +181,7 @@ class AssignCounseling(forms.Form):
         action_type_field = 'action_type'
         action_type = self.cleaned_data[action_type_field]
 
-        if self.counseling.action_type != self.cleaned_data[action_type_field] and not (self.cleaned_data['pd_check_override'] or (self.counseling and self.counseling.override_by and self.counseling.action_type == self.cleaned_data['action_type'])):
+        if not self.counseling or self.counseling and self.counseling.action_type != self.cleaned_data[action_type_field] and not (self.cleaned_data['pd_check_override'] or (self.counseling and self.counseling.override_by and self.counseling.action_type == self.cleaned_data['action_type'])):
             if action_type != '6' and action_type != '5':
                 history = {
                     '0': False,


### PR DESCRIPTION
This was caused by no checking if there was a counseling first